### PR TITLE
port autoware_iv_msgs to autoware_auto_msgs

### DIFF
--- a/include/ars408_ros/ars408_ros_node.hpp
+++ b/include/ars408_ros/ars408_ros_node.hpp
@@ -15,51 +15,55 @@
 #ifndef ARS408_ROS__ARS408_ROS_NODE_HPP_
 #define ARS408_ROS__ARS408_ROS_NODE_HPP_
 
+#include "ars408_ros/ars408_driver.hpp"
+#include "rclcpp/rclcpp.hpp"
+
+#include "autoware_auto_perception_msgs/msg/detected_objects.hpp"
+#include "autoware_auto_perception_msgs/msg/tracked_objects.hpp"
+#include "can_msgs/msg/frame.hpp"
+#include "unique_identifier_msgs/msg/uuid.hpp"
+
 #include <random>
 #include <string>
 #include <unordered_map>
 #include <vector>
 
-#include "autoware_perception_msgs/msg/dynamic_object_array.hpp"
-#include "can_msgs/msg/frame.hpp"
-#include "rclcpp/rclcpp.hpp"
-#include "unique_identifier_msgs/msg/uuid.hpp"
-
-#include "ars408_ros/ars408_driver.hpp"
-
 class PeContinentalArs408Node : public rclcpp::Node
 {
   rclcpp::Subscription<can_msgs::msg::Frame>::SharedPtr subscriber_can_raw_;
   rclcpp::Subscription<can_msgs::msg::Frame>::SharedPtr subscription_;
-  rclcpp::Publisher<autoware_perception_msgs::msg::DynamicObjectArray>
-  ::SharedPtr publisher_dynamic_object_array_;
+  rclcpp::Publisher<autoware_auto_perception_msgs::msg::DetectedObjects>::SharedPtr
+    publisher_detected_objects_;
+  rclcpp::Publisher<autoware_auto_perception_msgs::msg::TrackedObjects>::SharedPtr
+    publisher_tracked_objects_;
 
   std::string output_frame_;
 
   const uint8_t max_radar_id = 255;
   std::vector<unique_identifier_msgs::msg::UUID> UUID_table_;
+  bool use_tracked_object_;
 
-  ars408::Ars408Driver ars408_driver_ {};
+  ars408::Ars408Driver ars408_driver_{};
 
   void CanFrameCallback(const can_msgs::msg::Frame::SharedPtr can_msg);
 
   void GenerateUUIDTable();
 
-  autoware_perception_msgs::msg::DynamicObject
-  ConvertRadarObjectToAwDynamicObject(const ars408::RadarObject & in_object);
+  autoware_auto_perception_msgs::msg::DetectedObject ConvertRadarObjectToAwDetectedObject(
+    const ars408::RadarObject & in_object);
 
-  static uint32_t
-  ConvertRadarClassToAwSemanticClass(
+  autoware_auto_perception_msgs::msg::TrackedObject ConvertRadarObjectToAwTrackedObject(
+    const ars408::RadarObject & in_object);
+
+  static uint32_t ConvertRadarClassToAwSemanticClass(
     const ars408::Obj_3_Extended::ObjectClassProperty & in_radar_class);
 
-  static unique_identifier_msgs::msg::UUID
-  GenerateRandomUUID();
+  static unique_identifier_msgs::msg::UUID GenerateRandomUUID();
 
 public:
   explicit PeContinentalArs408Node(const rclcpp::NodeOptions & node_options);
   void RadarDetectedObjectsCallback(
-    const std::unordered_map<uint8_t,
-    ars408::RadarObject> & detected_objects);
+    const std::unordered_map<uint8_t, ars408::RadarObject> & detected_objects);
   void Run();
 };
 

--- a/include/ars408_ros/ars408_ros_node.hpp
+++ b/include/ars408_ros/ars408_ros_node.hpp
@@ -41,7 +41,7 @@ class PeContinentalArs408Node : public rclcpp::Node
 
   const uint8_t max_radar_id = 255;
   std::vector<unique_identifier_msgs::msg::UUID> UUID_table_;
-  bool use_tracked_object_;
+  bool publish_tracked_object_;
 
   ars408::Ars408Driver ars408_driver_{};
 

--- a/launch/continental_ars408.launch.xml
+++ b/launch/continental_ars408.launch.xml
@@ -3,6 +3,7 @@
   <arg name="receiver_interval_sec" default="0.01" />
   <arg name="input/frame" default="from_can_bus" />
   <arg name="output/objects" default="objects" />
+  <arg name="use_tracked_object" default="false"/>
 
   <include file="$(find-pkg-share ros2_socketcan)/launch/socket_can_receiver.launch.py">
     <arg name="interface" value="$(var interface)" />
@@ -12,5 +13,6 @@
   <node pkg="pe_ars408_ros" exec="pe_ars408_node" name="pe_ars408_node" output="screen">
     <remap from="~/input/frame" to="$(var input/frame)" />
     <remap from="~/output/objects" to="$(var output/objects)" />
+    <param name="use_tracked_object" value="$(var use_tracked_object)"/>
   </node>
 </launch>

--- a/launch/continental_ars408.launch.xml
+++ b/launch/continental_ars408.launch.xml
@@ -3,7 +3,7 @@
   <arg name="receiver_interval_sec" default="0.01" />
   <arg name="input/frame" default="from_can_bus" />
   <arg name="output/objects" default="objects" />
-  <arg name="use_tracked_object" default="false"/>
+  <arg name="publish_tracked_object" default="false"/>
 
   <include file="$(find-pkg-share ros2_socketcan)/launch/socket_can_receiver.launch.py">
     <arg name="interface" value="$(var interface)" />
@@ -13,6 +13,6 @@
   <node pkg="pe_ars408_ros" exec="pe_ars408_node" name="pe_ars408_node" output="screen">
     <remap from="~/input/frame" to="$(var input/frame)" />
     <remap from="~/output/objects" to="$(var output/objects)" />
-    <param name="use_tracked_object" value="$(var use_tracked_object)"/>
+    <param name="publish_tracked_object" value="$(var publish_tracked_object)"/>
   </node>
 </launch>

--- a/package.xml
+++ b/package.xml
@@ -7,7 +7,7 @@
   <license>Private</license>
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <depend>autoware_perception_msgs</depend>
+  <depend>autoware_auto_perception_msgs</depend>
   <depend>can_msgs</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>

--- a/src/ars408_ros_node.cpp
+++ b/src/ars408_ros_node.cpp
@@ -12,14 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "ars408_ros/ars408_ros_node.hpp"
+
 #include <string>
 #include <unordered_map>
-
-#include "ars408_ros/ars408_ros_node.hpp"
 
 PeContinentalArs408Node::PeContinentalArs408Node(const rclcpp::NodeOptions & node_options)
 : Node("ars408_node", node_options)
 {
+  use_tracked_object_ = declare_parameter("use_tracked_object", false);
   GenerateUUIDTable();
   Run();
 }
@@ -31,86 +32,126 @@ void PeContinentalArs408Node::CanFrameCallback(const can_msgs::msg::Frame::Share
   }
 }
 
-uint32_t
-PeContinentalArs408Node::ConvertRadarClassToAwSemanticClass(
+uint32_t PeContinentalArs408Node::ConvertRadarClassToAwSemanticClass(
   const ars408::Obj_3_Extended::ObjectClassProperty & in_radar_class)
 {
   switch (in_radar_class) {
     case ars408::Obj_3_Extended::BICYCLE:
-      return autoware_perception_msgs::msg::Semantic::BICYCLE;
+      return autoware_auto_perception_msgs::msg::ObjectClassification::BICYCLE;
       break;
     case ars408::Obj_3_Extended::CAR:
-      return autoware_perception_msgs::msg::Semantic::CAR;
+      return autoware_auto_perception_msgs::msg::ObjectClassification::CAR;
       break;
     case ars408::Obj_3_Extended::TRUCK:
-      return autoware_perception_msgs::msg::Semantic::TRUCK;
+      return autoware_auto_perception_msgs::msg::ObjectClassification::TRUCK;
       break;
     case ars408::Obj_3_Extended::MOTORCYCLE:
-      return autoware_perception_msgs::msg::Semantic::MOTORBIKE;
+      return autoware_auto_perception_msgs::msg::ObjectClassification::MOTORCYCLE;
       break;
     case ars408::Obj_3_Extended::POINT:
     case ars408::Obj_3_Extended::RESERVED_01:
     case ars408::Obj_3_Extended::WIDE:
     case ars408::Obj_3_Extended::RESERVED_02:
     default:
-      return autoware_perception_msgs::msg::Semantic::UNKNOWN;
+      return autoware_auto_perception_msgs::msg::ObjectClassification::UNKNOWN;
       break;
   }
 }
 
-autoware_perception_msgs::msg::DynamicObject
-PeContinentalArs408Node::ConvertRadarObjectToAwDynamicObject(const ars408::RadarObject & in_object)
+autoware_auto_perception_msgs::msg::DetectedObject
+PeContinentalArs408Node::ConvertRadarObjectToAwDetectedObject(const ars408::RadarObject & in_object)
 {
-  autoware_perception_msgs::msg::DynamicObject out_object;
+  autoware_auto_perception_msgs::msg::ObjectClassification classification;
+  autoware_auto_perception_msgs::msg::DetectedObject out_object;
 
-//  out_object.id = unique_identifier_msgs::toMsg(unique_identifier_msgs::fromRandom());
-  out_object.id = UUID_table_[in_object.id];
-  out_object.semantic.type = ConvertRadarClassToAwSemanticClass(in_object.object_class);
-  out_object.shape.type = autoware_perception_msgs::msg::Shape::BOUNDING_BOX;
+  classification.label = ConvertRadarClassToAwSemanticClass(in_object.object_class);
+  classification.probability = in_object.rcs;
+  out_object.classification.emplace_back(classification);
+  out_object.shape.type = autoware_auto_perception_msgs::msg::Shape::BOUNDING_BOX;
   out_object.shape.dimensions.x = 1.0;
   out_object.shape.dimensions.y = 1.0;
   out_object.shape.dimensions.z = 2.0;
 
-  out_object.semantic.confidence = in_object.rcs;
-  out_object.state.pose_covariance.pose.position.x = in_object.distance_long_x;
-  out_object.state.pose_covariance.pose.position.y = in_object.distance_lat_y;
+  out_object.kinematics.pose_with_covariance.pose.position.x = in_object.distance_long_x;
+  out_object.kinematics.pose_with_covariance.pose.position.y = in_object.distance_lat_y;
 
-  out_object.state.twist_reliable = true;
-  out_object.state.twist_covariance.twist.linear.x = in_object.speed_long_x;
-  out_object.state.twist_covariance.twist.linear.y = in_object.speed_lat_y;
-  out_object.state.twist_covariance.twist.angular.x = in_object.speed_long_x;
-  out_object.state.twist_covariance.twist.angular.y = in_object.speed_lat_y;
+  out_object.kinematics.has_twist = true;
+  out_object.kinematics.twist_with_covariance.twist.linear.x = in_object.speed_long_x;
+  out_object.kinematics.twist_with_covariance.twist.linear.y = in_object.speed_lat_y;
+  out_object.kinematics.twist_with_covariance.twist.angular.x = in_object.speed_long_x;
+  out_object.kinematics.twist_with_covariance.twist.angular.y = in_object.speed_lat_y;
 
-  out_object.state.acceleration_reliable = true;
-  out_object.state.acceleration_covariance.accel.angular.x = in_object.rel_acceleration_long_x;
-  out_object.state.acceleration_covariance.accel.angular.y = in_object.rel_acceleration_lat_y;
+  return out_object;
+}
+
+autoware_auto_perception_msgs::msg::TrackedObject
+PeContinentalArs408Node::ConvertRadarObjectToAwTrackedObject(const ars408::RadarObject & in_object)
+{
+  autoware_auto_perception_msgs::msg::ObjectClassification classification;
+  autoware_auto_perception_msgs::msg::TrackedObject out_object;
+
+  out_object.object_id = UUID_table_[in_object.id];
+  classification.label = ConvertRadarClassToAwSemanticClass(in_object.object_class);
+  classification.probability = in_object.rcs;
+  out_object.classification.emplace_back(classification);
+  out_object.shape.type = autoware_auto_perception_msgs::msg::Shape::BOUNDING_BOX;
+  out_object.shape.dimensions.x = 1.0;
+  out_object.shape.dimensions.y = 1.0;
+  out_object.shape.dimensions.z = 2.0;
+
+  out_object.kinematics.pose_with_covariance.pose.position.x = in_object.distance_long_x;
+  out_object.kinematics.pose_with_covariance.pose.position.y = in_object.distance_lat_y;
+
+  out_object.kinematics.orientation_availability = true;
+  out_object.kinematics.twist_with_covariance.twist.linear.x = in_object.speed_long_x;
+  out_object.kinematics.twist_with_covariance.twist.linear.y = in_object.speed_lat_y;
+  out_object.kinematics.twist_with_covariance.twist.angular.x = in_object.speed_long_x;
+  out_object.kinematics.twist_with_covariance.twist.angular.y = in_object.speed_lat_y;
+
+  out_object.kinematics.acceleration_with_covariance.accel.angular.x =
+    in_object.rel_acceleration_long_x;
+  out_object.kinematics.acceleration_with_covariance.accel.angular.y =
+    in_object.rel_acceleration_lat_y;
 
   return out_object;
 }
 
 void PeContinentalArs408Node::RadarDetectedObjectsCallback(
-  const std::unordered_map<uint8_t,
-  ars408::RadarObject> & detected_objects)
+  const std::unordered_map<uint8_t, ars408::RadarObject> & detected_objects)
 {
-  autoware_perception_msgs::msg::DynamicObjectArray aw_output_objects;
+  if (use_tracked_object_) {
+    autoware_auto_perception_msgs::msg::TrackedObjects aw_output_objects;
 
-  aw_output_objects.header.frame_id = output_frame_;
-  rclcpp::Time current_time = this->get_clock()->now();
-  aw_output_objects.header.stamp = current_time;
+    aw_output_objects.header.frame_id = output_frame_;
+    rclcpp::Time current_time = this->get_clock()->now();
+    aw_output_objects.header.stamp = current_time;
 
-  for (const auto & object : detected_objects) {
-    // RCLCPP_INFO_STREAM(this->get_logger(), object.second.ToString());
-    autoware_perception_msgs::msg::DynamicObject aw_object = ConvertRadarObjectToAwDynamicObject(
-      object.second);
-    aw_output_objects.objects.emplace_back(aw_object);
+    for (const auto & object : detected_objects) {
+      autoware_auto_perception_msgs::msg::TrackedObject aw_object =
+        ConvertRadarObjectToAwTrackedObject(object.second);
+      aw_output_objects.objects.emplace_back(aw_object);
+      publisher_tracked_objects_->publish(aw_output_objects);
+    }
+  } else {
+    autoware_auto_perception_msgs::msg::DetectedObjects aw_output_objects;
+
+    aw_output_objects.header.frame_id = output_frame_;
+    rclcpp::Time current_time = this->get_clock()->now();
+    aw_output_objects.header.stamp = current_time;
+
+    for (const auto & object : detected_objects) {
+      autoware_auto_perception_msgs::msg::DetectedObject aw_object =
+        ConvertRadarObjectToAwDetectedObject(object.second);
+      aw_output_objects.objects.emplace_back(aw_object);
+      publisher_detected_objects_->publish(aw_output_objects);
+    }
   }
-  publisher_dynamic_object_array_->publish(aw_output_objects);
 }
 
 unique_identifier_msgs::msg::UUID PeContinentalArs408Node::GenerateRandomUUID()
 {
   unique_identifier_msgs::msg::UUID uuid;
-  std::mt19937 gen(std::random_device{} ());
+  std::mt19937 gen(std::random_device{}());
   std::independent_bits_engine<std::mt19937, 8, uint8_t> bit_eng(gen);
   std::generate(uuid.uuid.begin(), uuid.uuid.end(), bit_eng);
   return uuid;
@@ -123,26 +164,25 @@ void PeContinentalArs408Node::GenerateUUIDTable()
   }
 }
 
-
 void PeContinentalArs408Node::Run()
 {
   output_frame_ = this->declare_parameter<std::string>("output_frame", "ars408");
 
   ars408_driver_.RegisterDetectedObjectsCallback(
-    std::bind(
-      &PeContinentalArs408Node::RadarDetectedObjectsCallback,
-      this,
-      std::placeholders::_1));
+    std::bind(&PeContinentalArs408Node::RadarDetectedObjectsCallback, this, std::placeholders::_1));
 
   subscription_ = this->create_subscription<can_msgs::msg::Frame>(
     "~/input/frame", 10,
-    std::bind(
-      &PeContinentalArs408Node::CanFrameCallback,
-      this, std::placeholders::_1));
-
-  publisher_dynamic_object_array_ =
-    this->create_publisher<autoware_perception_msgs::msg::DynamicObjectArray>(
-    "~/output/objects", 10);
+    std::bind(&PeContinentalArs408Node::CanFrameCallback, this, std::placeholders::_1));
+  if (use_tracked_object_) {
+    publisher_tracked_objects_ =
+      this->create_publisher<autoware_auto_perception_msgs::msg::TrackedObjects>(
+        "~/output/objects", 10);
+  } else {
+    publisher_detected_objects_ =
+      this->create_publisher<autoware_auto_perception_msgs::msg::DetectedObjects>(
+        "~/output/objects", 10);
+  }
 }
 
 #include "rclcpp_components/register_node_macro.hpp"

--- a/src/ars408_ros_node.cpp
+++ b/src/ars408_ros_node.cpp
@@ -67,13 +67,18 @@ PeContinentalArs408Node::ConvertRadarObjectToAwDetectedObject(const ars408::Rada
   classification.label = ConvertRadarClassToAwSemanticClass(in_object.object_class);
   classification.probability = in_object.rcs;
   out_object.classification.emplace_back(classification);
+  out_object.existence_probability = in_object.probability_existence;
   out_object.shape.type = autoware_auto_perception_msgs::msg::Shape::BOUNDING_BOX;
   out_object.shape.dimensions.x = 1.0;
   out_object.shape.dimensions.y = 1.0;
   out_object.shape.dimensions.z = 2.0;
 
+  out_object.kinematics.orientation_availability =
+    autoware_auto_perception_msgs::msg::DetectedObjectKinematics::AVAILABLE;
+  out_object.kinematics.has_position_covariance = false;
   out_object.kinematics.pose_with_covariance.pose.position.x = in_object.distance_long_x;
   out_object.kinematics.pose_with_covariance.pose.position.y = in_object.distance_lat_y;
+  out_object.kinematics.pose_with_covariance.pose.orientation.z = in_object.orientation_angle;
 
   out_object.kinematics.has_twist = true;
   out_object.kinematics.has_twist_covariance = false;
@@ -100,8 +105,11 @@ PeContinentalArs408Node::ConvertRadarObjectToAwTrackedObject(const ars408::Radar
   out_object.shape.dimensions.y = 1.0;
   out_object.shape.dimensions.z = 2.0;
 
+  out_object.kinematics.orientation_availability =
+    autoware_auto_perception_msgs::msg::TrackedObjectKinematics::AVAILABLE;
   out_object.kinematics.pose_with_covariance.pose.position.x = in_object.distance_long_x;
   out_object.kinematics.pose_with_covariance.pose.position.y = in_object.distance_lat_y;
+  out_object.kinematics.pose_with_covariance.pose.orientation.z = in_object.orientation_angle;
 
   out_object.kinematics.twist_with_covariance.twist.linear.x = in_object.speed_long_x;
   out_object.kinematics.twist_with_covariance.twist.linear.y = in_object.speed_lat_y;

--- a/src/ars408_ros_node.cpp
+++ b/src/ars408_ros_node.cpp
@@ -76,6 +76,7 @@ PeContinentalArs408Node::ConvertRadarObjectToAwDetectedObject(const ars408::Rada
   out_object.kinematics.pose_with_covariance.pose.position.y = in_object.distance_lat_y;
 
   out_object.kinematics.has_twist = true;
+  out_object.kinematics.has_twist_covariance = false;
   out_object.kinematics.twist_with_covariance.twist.linear.x = in_object.speed_long_x;
   out_object.kinematics.twist_with_covariance.twist.linear.y = in_object.speed_lat_y;
   out_object.kinematics.twist_with_covariance.twist.angular.x = in_object.speed_long_x;

--- a/src/ars408_ros_node.cpp
+++ b/src/ars408_ros_node.cpp
@@ -20,7 +20,7 @@
 PeContinentalArs408Node::PeContinentalArs408Node(const rclcpp::NodeOptions & node_options)
 : Node("ars408_node", node_options)
 {
-  use_tracked_object_ = declare_parameter("use_tracked_object", false);
+  publish_tracked_object_ = declare_parameter("use_tracked_object", false);
   GenerateUUIDTable();
   Run();
 }
@@ -119,7 +119,7 @@ PeContinentalArs408Node::ConvertRadarObjectToAwTrackedObject(const ars408::Radar
 void PeContinentalArs408Node::RadarDetectedObjectsCallback(
   const std::unordered_map<uint8_t, ars408::RadarObject> & detected_objects)
 {
-  if (use_tracked_object_) {
+  if (publish_tracked_object_) {
     autoware_auto_perception_msgs::msg::TrackedObjects aw_output_objects;
 
     aw_output_objects.header.frame_id = output_frame_;
@@ -174,7 +174,7 @@ void PeContinentalArs408Node::Run()
   subscription_ = this->create_subscription<can_msgs::msg::Frame>(
     "~/input/frame", 10,
     std::bind(&PeContinentalArs408Node::CanFrameCallback, this, std::placeholders::_1));
-  if (use_tracked_object_) {
+  if (publish_tracked_object_) {
     publisher_tracked_objects_ =
       this->create_publisher<autoware_auto_perception_msgs::msg::TrackedObjects>(
         "~/output/objects", 10);

--- a/src/ars408_ros_node.cpp
+++ b/src/ars408_ros_node.cpp
@@ -103,7 +103,6 @@ PeContinentalArs408Node::ConvertRadarObjectToAwTrackedObject(const ars408::Radar
   out_object.kinematics.pose_with_covariance.pose.position.x = in_object.distance_long_x;
   out_object.kinematics.pose_with_covariance.pose.position.y = in_object.distance_lat_y;
 
-  out_object.kinematics.orientation_availability = true;
   out_object.kinematics.twist_with_covariance.twist.linear.x = in_object.speed_long_x;
   out_object.kinematics.twist_with_covariance.twist.linear.y = in_object.speed_lat_y;
   out_object.kinematics.twist_with_covariance.twist.angular.x = in_object.speed_long_x;


### PR DESCRIPTION
porting autoware_iv_msgs to autoware_auto_msgs.
DynamicObject divided into DetectedObject and TrackedObject.
Also, use the ros parameter "use_tracked_object" to select whether to use a DetectedObject or a TrackedObject.