### PR TITLE
fix: add object size parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,9 +62,9 @@ ros2 launch continental_ars408_socket_can.launch.xml
   - If this parameter is set to false (default value), the driver will publish output after receiving a complete cycle of sequential data from the CAN data topic.
   - If this parameter is set to true, the driver will publish output every time data is received from the CAN data topic.
 - `size_x`
-  - The assumed x-axis size of output objects. [m]
+  - The assumed x-axis size of output objects [m]. The default parameter is 1.8, which derive from distance resolution measuring of ARS408 for far range.
 - `size_y`
-  - The assumed y-axis size of output objects. [m]
+  - The assumed y-axis size of output objects [m]. The default parameter is 1.8, which derive from distance resolution measuring of ARS408 for far range.
 
 ### launcher
 

--- a/README.md
+++ b/README.md
@@ -62,9 +62,9 @@ ros2 launch continental_ars408_socket_can.launch.xml
   - If this parameter is set to false (default value), the driver will publish output after receiving a complete cycle of sequential data from the CAN data topic.
   - If this parameter is set to true, the driver will publish output every time data is received from the CAN data topic.
 - `size_x`
-  - The size of x [m]
+  - The assumed x-axis size of output objects. [m]
 - `size_y`
-  - The size of y [m]
+  - The assumed y-axis size of output objects. [m]
 
 ### launcher
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,10 @@ ros2 launch continental_ars408_socket_can.launch.xml
   - The bool parameter to determine output publishing behavior.
   - If this parameter is set to false (default value), the driver will publish output after receiving a complete cycle of sequential data from the CAN data topic.
   - If this parameter is set to true, the driver will publish output every time data is received from the CAN data topic.
+- `size_x`
+  - The size of x [m]
+- `size_y`
+  - The size of y [m]
 
 ### launcher
 

--- a/include/ars408_ros/ars408_ros_node.hpp
+++ b/include/ars408_ros/ars408_ros_node.hpp
@@ -35,11 +35,14 @@ class PeContinentalArs408Node : public rclcpp::Node
   rclcpp::Publisher<radar_msgs::msg::RadarTracks>::SharedPtr publisher_radar_tracks_;
   rclcpp::Publisher<radar_msgs::msg::RadarScan>::SharedPtr publisher_radar_scan_;
 
-  std::string output_frame_;
   can_msgs::msg::Frame::ConstSharedPtr can_data_;
+
+  std::string output_frame_;
   bool publish_radar_track_;
   bool publish_radar_scan_;
   bool sequential_publish_;
+  double size_x_;
+  double size_y_;
 
   const uint8_t max_radar_id = 255;
   std::vector<unique_identifier_msgs::msg::UUID> UUID_table_;

--- a/launch/continental_ars408.launch.xml
+++ b/launch/continental_ars408.launch.xml
@@ -8,8 +8,8 @@
   <arg name="publish_radar_track" default="true" />
   <arg name="publish_radar_scan" default="false" />
   <arg name="sequential_publish" default="false" />
-  <arg name="size_x" default="3.5" />
-  <arg name="size_y" default="1.5" />
+  <arg name="size_x" default="1.8" />
+  <arg name="size_y" default="1.8" />
 
   <node pkg="pe_ars408_ros" exec="pe_ars408_node" name="pe_ars408_node" output="screen">
     <remap from="~/input/frame" to="$(var input/frame)" />

--- a/launch/continental_ars408.launch.xml
+++ b/launch/continental_ars408.launch.xml
@@ -4,10 +4,12 @@
   <arg name="output/objects" default="objects_raw" />
   <arg name="output/scan" default="scan" />
   <!-- parameter -->
+  <arg name="output_frame" default="ars408" />
   <arg name="publish_radar_track" default="true" />
   <arg name="publish_radar_scan" default="false" />
-  <arg name="output_frame" default="ars408" />
   <arg name="sequential_publish" default="false" />
+  <arg name="size_x" default="3.5" />
+  <arg name="size_y" default="1.5" />
 
   <node pkg="pe_ars408_ros" exec="pe_ars408_node" name="pe_ars408_node" output="screen">
     <remap from="~/input/frame" to="$(var input/frame)" />
@@ -17,5 +19,7 @@
     <param name="publish_radar_scan" value="$(var publish_radar_scan)" />
     <param name="output_frame" value="$(var output_frame)" />
     <param name="sequential_publish" value="$(var sequential_publish)" />
+    <param name="size_x" value="$(var size_x)" />
+    <param name="size_y" value="$(var size_y)" />
   </node>
 </launch>

--- a/launch/continental_ars408_socket_can.launch.xml
+++ b/launch/continental_ars408_socket_can.launch.xml
@@ -14,8 +14,8 @@
   <arg name="publish_radar_scan" default="false" />
   <arg name="output_frame" default="ars408" />
   <arg name="sequential_publish" default="false" />
-  <arg name="size_x" default="3.5" />
-  <arg name="size_y" default="1.5" />
+  <arg name="size_x" default="1.8" />
+  <arg name="size_y" default="1.8" />
 
   <include file="$(find-pkg-share ros2_socketcan)/launch/socket_can_receiver.launch.py" if="$(var launch_driver)">
     <arg name="interface" value="$(var interface)" />

--- a/launch/continental_ars408_socket_can.launch.xml
+++ b/launch/continental_ars408_socket_can.launch.xml
@@ -14,6 +14,8 @@
   <arg name="publish_radar_scan" default="false" />
   <arg name="output_frame" default="ars408" />
   <arg name="sequential_publish" default="false" />
+  <arg name="size_x" default="3.5" />
+  <arg name="size_y" default="1.5" />
 
   <include file="$(find-pkg-share ros2_socketcan)/launch/socket_can_receiver.launch.py" if="$(var launch_driver)">
     <arg name="interface" value="$(var interface)" />
@@ -27,6 +29,8 @@
     <arg name="publish_radar_track" value="$(var publish_radar_track)" />
     <arg name="publish_radar_scan" value="$(var publish_radar_scan)" />
     <arg name="output_frame" value="$(var output_frame)" />
-    <arg name="sequential_publish" default="$(var sequential_publish)" />
+    <arg name="sequential_publish" value="$(var sequential_publish)" />
+    <arg name="size_x" value="$(var size_x)" />
+    <arg name="size_y" value="$(var size_y)" />
   </include>
 </launch>

--- a/src/ars408_ros_node.cpp
+++ b/src/ars408_ros_node.cpp
@@ -149,8 +149,8 @@ void PeContinentalArs408Node::Run()
   publish_radar_track_ = this->declare_parameter<bool>("publish_radar_track", true);
   publish_radar_scan_ = this->declare_parameter<bool>("publish_radar_scan", false);
   sequential_publish_ = this->declare_parameter<bool>("sequential_publish", false);
-  size_x_ = this->declare_parameter<double>("size_x", 3.5);
-  size_y_ = this->declare_parameter<double>("size_y", 1.5);
+  size_x_ = this->declare_parameter<double>("size_x", 1.8);
+  size_y_ = this->declare_parameter<double>("size_y", 1.8);
 
   ars408_driver_.RegisterDetectedObjectsCallback(
     std::bind(&PeContinentalArs408Node::RadarDetectedObjectsCallback, this, std::placeholders::_1),

--- a/src/ars408_ros_node.cpp
+++ b/src/ars408_ros_node.cpp
@@ -76,8 +76,8 @@ radar_msgs::msg::RadarTrack PeContinentalArs408Node::ConvertRadarObjectToRadarTr
   out_object.acceleration.x = in_object.rel_acceleration_long_x;
   out_object.acceleration.y = in_object.rel_acceleration_lat_y;
 
-  out_object.size.x = 2.5;
-  out_object.size.y = 1.0;
+  out_object.size.x = size_x_;
+  out_object.size.y = size_y_;
   out_object.size.z = 1.0;
 
   out_object.classification = ConvertRadarClassToAwSemanticClass(in_object.object_class);
@@ -149,6 +149,8 @@ void PeContinentalArs408Node::Run()
   publish_radar_track_ = this->declare_parameter<bool>("publish_radar_track", true);
   publish_radar_scan_ = this->declare_parameter<bool>("publish_radar_scan", false);
   sequential_publish_ = this->declare_parameter<bool>("sequential_publish", false);
+  size_x_ = this->declare_parameter<double>("size_x", 3.5);
+  size_y_ = this->declare_parameter<double>("size_y", 1.5);
 
   ars408_driver_.RegisterDetectedObjectsCallback(
     std::bind(&PeContinentalArs408Node::RadarDetectedObjectsCallback, this, std::placeholders::_1),


### PR DESCRIPTION
To adjust for parameters related to footprint area like min_area parameters of tracking, this PR add object size parameters to ARS408 driver.

Signed-off-by: scepter914 scepter914@gmail.com